### PR TITLE
[trainer] Fix rubocop lint offenses in test_parser_spec

### DIFF
--- a/trainer/spec/test_parser_spec.rb
+++ b/trainer/spec/test_parser_spec.rb
@@ -290,8 +290,7 @@ describe Trainer do
               name: "testFlaky()",
               duration: 0.5,
               test_status: "Failure",
-              parent: test_group
-            )
+              parent: test_group)
             allow(t).to receive(:find_failure).and_return(failure)
             t
           end
@@ -301,8 +300,7 @@ describe Trainer do
               name: "testFlaky()",
               duration: 0.1,
               test_status: "Skipped",
-              parent: test_group
-            )
+              parent: test_group)
             allow(t).to receive(:find_failure).and_return(nil)
             t
           end
@@ -312,15 +310,13 @@ describe Trainer do
               all_tests: [failing_test, skipped_test],
               project_relative_path: "MyApp.xcodeproj",
               target_name: "MyTests",
-              name: "MyTests"
-            )
+              name: "MyTests")
           end
 
           let(:plan_run_summary) do
             double("plan_run_summary",
               name: "Test Scheme Action",
-              testable_summaries: [testable_summary]
-            )
+              testable_summaries: [testable_summary])
           end
 
           let(:summaries_wrapper) do


### PR DESCRIPTION
<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist

- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I see several green `ci/circleci` builds in the "All checks have passed" section of my PR ([connect CircleCI to GitHub](https://support.circleci.com/hc/en-us/articles/360008097173-Why-aren-t-pull-requests-triggering-jobs-on-my-organization-) if not)
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.
- [ ] I've added or updated relevant unit tests.

### Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue following this format:
Resolves #999999
-->

### Description

<!-- Describe your changes in detail, as well as how you tested them. -->

### Testing Steps

<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
